### PR TITLE
Remove bitcoinjs-lib dependency. Implement only the needed methods

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -5,7 +5,7 @@ const ERROR_MESSAGES = {
     INVALID_DHASH: 'derivationArgsHash must be hash represented as a 64 characters string',
     INVALID_REDEEM_SCRIPT: 'redeemScript must be a Buffer',
     NOT_A_FLYOVER_REDEEM_SCRIPT: 'redeemScript is not a flyover redeem script',
-    INVALID_PUBLIC_KEYS_COUNT: 'the number of public keys must be between 1 and 16'
+    INVALID_PUBLIC_KEYS_COUNT: 'the number of public keys must be between 1 and 20'
 }
 
 const MAX_CSV_VALUE = 65535; // 2^16 - 1, since bitcoin will interpret up to 16 bits as the CSV value

--- a/constants.js
+++ b/constants.js
@@ -4,7 +4,8 @@ const ERROR_MESSAGES = {
     INVALID_CSV_VALUE: 'csvValue is required in the number format and should be between 1 and 65535',
     INVALID_DHASH: 'derivationArgsHash must be hash represented as a 64 characters string',
     INVALID_REDEEM_SCRIPT: 'redeemScript must be a Buffer',
-    NOT_A_FLYOVER_REDEEM_SCRIPT: 'redeemScript is not a flyover redeem script'
+    NOT_A_FLYOVER_REDEEM_SCRIPT: 'redeemScript is not a flyover redeem script',
+    INVALID_PUBLIC_KEYS_COUNT: 'the number of public keys must be between 1 and 16'
 }
 
 const MAX_CSV_VALUE = 65535; // 2^16 - 1, since bitcoin will interpret up to 16 bits as the CSV value

--- a/index.js
+++ b/index.js
@@ -12,8 +12,11 @@ const buildStandardMultiSigRedeemScript = (btcPublicKeys) => {
         .map(hex => hex instanceof Buffer ? hex: Buffer.from(hex, 'hex'))
         .sort((a, b) => a.compare(b));
 
-    const m = decimalToOpCode[parseInt(pubkeys.length / 2) + 1];
     const n = decimalToOpCode[pubkeys.length];
+    if (n === undefined) {
+        throw new Error(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
+    }
+    const m = decimalToOpCode[parseInt(pubkeys.length / 2) + 1];
 
     // OP_M <pushbyte(pubkey)>... OP_N OP_CHECKMULTISIG
     return Buffer.concat([
@@ -76,7 +79,7 @@ const buildPowpegRedeemScript = (powpegBtcPublicKeys, erpBtcPublicKeys, csvValue
     position+= emergencyRedeemScript.length / 2;
     redeemScript.write(numberToHexString(OPS.OP_ENDIF), position, 'hex');
 
-    return Buffer.from(redeemScript, 'hex');
+    return redeemScript;
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,6 +1,24 @@
 const { ERROR_MESSAGES, MAX_CSV_VALUE } = require('./constants');
 const { OPS, numberToHexString, decimalToOpCode, signedNumberToHexStringLE } = require('./utils');
 
+// OP_CHECKMULTISIG only supports up to 20 keys (MAX_PUBKEYS_PER_MULTISIG in Bitcoin Script).
+const MIN_MULTISIG_PUBLIC_KEYS_COUNT = 1;
+const MAX_MULTISIG_PUBLIC_KEYS_COUNT = 20;
+
+/**
+ * Encodes a multisig M or N value as a script chunk. There's no OP_17..OP_20 opcode,
+ * so 1-16 push a single OP_N opcode while 17-20 push the number as minimally-encoded data.
+ * @param {Number} num
+ * @returns {Buffer}
+ */
+const encodeMultisigNumber = (num) => {
+    if (decimalToOpCode[num] !== undefined) {
+        return Buffer.from([decimalToOpCode[num]]);
+    }
+    const hex = signedNumberToHexStringLE(num);
+    return Buffer.concat([Buffer.from([hex.length / 2]), Buffer.from(hex, 'hex')]);
+};
+
 /**
  *
  * @param {String[] | Buffer[]} btcPublicKeys
@@ -12,17 +30,19 @@ const buildStandardMultiSigRedeemScript = (btcPublicKeys) => {
         .map(hex => hex instanceof Buffer ? hex: Buffer.from(hex, 'hex'))
         .sort((a, b) => a.compare(b));
 
-    const n = decimalToOpCode[pubkeys.length];
-    if (n === undefined) {
+    if (pubkeys.length < MIN_MULTISIG_PUBLIC_KEYS_COUNT || pubkeys.length > MAX_MULTISIG_PUBLIC_KEYS_COUNT) {
         throw new Error(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
     }
-    const m = decimalToOpCode[parseInt(pubkeys.length / 2) + 1];
+
+    const m = parseInt(pubkeys.length / 2) + 1;
+    const n = pubkeys.length;
 
     // OP_M <pushbyte(pubkey)>... OP_N OP_CHECKMULTISIG
     return Buffer.concat([
-        Buffer.from([m]),
+        encodeMultisigNumber(m),
         ...pubkeys.map(pubkey => Buffer.concat([Buffer.from([pubkey.length]), pubkey])),
-        Buffer.from([n, OPS.OP_CHECKMULTISIG])
+        encodeMultisigNumber(n),
+        Buffer.from([OPS.OP_CHECKMULTISIG])
     ]);
 };
 

--- a/index.js
+++ b/index.js
@@ -1,18 +1,26 @@
-const bitcoin = require('bitcoinjs-lib');
 const { ERROR_MESSAGES, MAX_CSV_VALUE } = require('./constants');
-const { numberToHexString, signedNumberToHexStringLE } = require('./utils');
+const { OPS, numberToHexString, decimalToOpCode, signedNumberToHexStringLE } = require('./utils');
 
 /**
- * 
- * @param {String[] | Buffer[]} btcPublicKeys 
+ *
+ * @param {String[] | Buffer[]} btcPublicKeys
  * @returns {Buffer}
  */
 const buildStandardMultiSigRedeemScript = (btcPublicKeys) => {
     // Parse to Buffer and sort keys
-    const defaultPubkeys = btcPublicKeys
+    const pubkeys = btcPublicKeys
         .map(hex => hex instanceof Buffer ? hex: Buffer.from(hex, 'hex'))
         .sort((a, b) => a.compare(b));
-    return Buffer.from(bitcoin.payments.p2ms({ m: parseInt(defaultPubkeys.length / 2) + 1, pubkeys: defaultPubkeys }).output);
+
+    const m = decimalToOpCode[parseInt(pubkeys.length / 2) + 1];
+    const n = decimalToOpCode[pubkeys.length];
+
+    // OP_M <pushbyte(pubkey)>... OP_N OP_CHECKMULTISIG
+    return Buffer.concat([
+        Buffer.from([m]),
+        ...pubkeys.map(pubkey => Buffer.concat([Buffer.from([pubkey.length]), pubkey])),
+        Buffer.from([n, OPS.OP_CHECKMULTISIG])
+    ]);
 };
 
 /**
@@ -51,22 +59,22 @@ const buildPowpegRedeemScript = (powpegBtcPublicKeys, erpBtcPublicKeys, csvValue
 
     const redeemScript = Buffer.alloc(bufferLength);
 
-    redeemScript.write(numberToHexString(bitcoin.script.OPS.OP_NOTIF), 'hex');
+    redeemScript.write(numberToHexString(OPS.OP_NOTIF), 'hex');
     redeemScript.write(defaultRedeemScript, 1, 'hex');
     let position = 1 + parseInt(defaultRedeemScript.length / 2);
-    redeemScript.write(numberToHexString(bitcoin.script.OPS.OP_ELSE), position, 'hex');
+    redeemScript.write(numberToHexString(OPS.OP_ELSE), position, 'hex');
     position+= 1;
     redeemScript.write(`0${csvLEHexValue.length / 2}`, position, 'hex'); // OP_PUSHBYTES
     position+= 1;
     redeemScript.write(csvLEHexValue, position, 'hex');
     position+= csvLEHexValue.length / 2;
-    redeemScript.write(numberToHexString(bitcoin.script.OPS.OP_CHECKSEQUENCEVERIFY), position, 'hex');
+    redeemScript.write(numberToHexString(OPS.OP_CHECKSEQUENCEVERIFY), position, 'hex');
     position+= 1;
-    redeemScript.write(numberToHexString(bitcoin.script.OPS.OP_DROP), position, 'hex');
+    redeemScript.write(numberToHexString(OPS.OP_DROP), position, 'hex');
     position+= 1;
     redeemScript.write(emergencyRedeemScript, position, 'hex');
     position+= emergencyRedeemScript.length / 2;
-    redeemScript.write(numberToHexString(bitcoin.script.OPS.OP_ENDIF), position, 'hex');
+    redeemScript.write(numberToHexString(OPS.OP_ENDIF), position, 'hex');
 
     return Buffer.from(redeemScript, 'hex');
 };
@@ -83,7 +91,7 @@ const buildFlyoverPrefix = (derivationArgsHash) => {
     const prefix = Buffer.alloc(34);
     prefix.write('20', 'hex'); // hash length
     prefix.write(derivationArgsHash, 1, 'hex');
-    prefix.write(numberToHexString(bitcoin.script.OPS.OP_DROP), prefix.length - 1, 'hex'); // DROP the hash
+    prefix.write(numberToHexString(OPS.OP_DROP), prefix.length - 1, 'hex'); // DROP the hash
 
     return prefix;
 };
@@ -107,6 +115,7 @@ const buildFlyoverRedeemScript = (powpegRedeemScript, derivationArgsHash) => {
 
 // Flyover prefix: OP_PUSHBYTES_32 (1) + 32-byte derivation hash + OP_DROP (1)
 const FLYOVER_PREFIX_LENGTH_IN_BYTES = 34;
+const OP_PUSHBYTES_32 = 0x20;
 
 /**
  * Checks whether a redeem script is a flyover redeem script, i.e. a powpeg redeem script prefixed
@@ -119,16 +128,12 @@ const isFlyoverRedeemScript = (redeemScript) => {
         throw new Error(ERROR_MESSAGES.INVALID_REDEEM_SCRIPT);
     }
 
-    const chunks = bitcoin.script.decompile(redeemScript);
-    if (!chunks || chunks.length < 3) {
-        return false;
-    }
-
-    const [derivationHash, dropOpcode] = chunks;
+    // Must have at least one more byte after the prefix - a bare
+    // "<hash> OP_DROP" with nothing left to guard is not a flyover script.
     return (
-        derivationHash instanceof Uint8Array &&
-        derivationHash.length === 32 &&
-        dropOpcode === bitcoin.script.OPS.OP_DROP
+        redeemScript.length > FLYOVER_PREFIX_LENGTH_IN_BYTES &&
+        redeemScript[0] === OP_PUSHBYTES_32 &&
+        redeemScript[FLYOVER_PREFIX_LENGTH_IN_BYTES - 1] === OPS.OP_DROP
     );
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@rsksmart/powpeg-redeemscript-parser",
       "version": "2.0.0",
       "license": "ISC",
-      "dependencies": {
-        "bitcoinjs-lib": "7.0.1"
-      },
       "devDependencies": {
         "@rsksmart/rsk-precompiled-abis": "9.0.0-VETIVER",
         "chai": "5.2.0",
@@ -484,7 +481,7 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+    "node_modules/@noble/hashes": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
@@ -492,18 +489,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -631,12 +616,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base-x": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
-      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.12",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
@@ -648,43 +627,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
-    },
-    "node_modules/bip174": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-3.0.0.tgz",
-      "integrity": "sha512-N3vz3rqikLEu0d6yQL8GTrSkpYb35NQKWMR7Hlza0lOj6ZOlvQ3Xr7N9Y+JPebaCVoEUHdBeBSuLxcHr71r+Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "uint8array-tools": "^0.0.9",
-        "varuint-bitcoin": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/bitcoinjs-lib": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-7.0.1.tgz",
-      "integrity": "sha512-vwEmpL5Tpj0I0RBdNkcDMXePoaYSTeKY6mL6/l5esbnTs+jGdPDuLp4NY1hSh6Zk5wSgePygZ4Wx5JJao30Pww==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0",
-        "bech32": "^2.0.0",
-        "bip174": "^3.0.0",
-        "bs58check": "^4.0.0",
-        "uint8array-tools": "^0.0.9",
-        "valibot": "^1.2.0",
-        "varuint-bitcoin": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -738,25 +680,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/bs58": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
-      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^5.0.0"
-      }
-    },
-    "node_modules/bs58check": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
-      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0",
-        "bs58": "^6.0.0"
-      }
-    },
     "node_modules/caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -784,9 +707,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001807",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001807.tgz",
+      "integrity": "sha512-daRXJ9EB/rdRgu7kV+TTl1YUKtlsMWblPl2sLnpg9DZae16QCegol6A1SmCE31Lm9mXC1sRWGt/krouH+/dl7Q==",
       "dev": true,
       "funding": [
         {
@@ -1093,9 +1016,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.401",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz",
-      "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1177,19 +1100,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/find-cache-dir": {
@@ -1863,9 +1773,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.52",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
-      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2881,15 +2791,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/uint8array-tools": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.9.tgz",
-      "integrity": "sha512-9vqDWmoSXOoi+K14zNaf6LBV51Q8MayF0/IiQs3GlygIKUYtog603e6virExkjjFosfJUBI4LhbQK1iq8IG11A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -2937,38 +2838,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/valibot": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
-      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/varuint-bitcoin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
-      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
-      "license": "MIT",
-      "dependencies": {
-        "uint8array-tools": "^0.0.8"
-      }
-    },
-    "node_modules/varuint-bitcoin/node_modules/uint8array-tools": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
-      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
   "engines": {
     "node": ">=24.0.0"
   },
-  "dependencies": {
-    "bitcoinjs-lib": "7.0.1"
-  },
   "devDependencies": {
     "@rsksmart/rsk-precompiled-abis": "9.0.0-VETIVER",
     "chai": "5.2.0",

--- a/test/redeem-script-parser.test.js
+++ b/test/redeem-script-parser.test.js
@@ -1,10 +1,13 @@
 const redeemScriptParser = require('../index');
-const opcodes = require('bitcoinjs-lib').script.OPS;
-const script = require('bitcoinjs-lib').script;
 const expect = require('chai').expect;
 const { ERROR_MESSAGES, MAX_CSV_VALUE } = require('../constants');
 const rawRedeemScripts = require('./resources/test-redeem-scripts.json');
-const { signedNumberToHexStringLE, hexToDecimal, numberToHexString, decimalToOpCode } = require('../utils');
+const { OPS: opcodes, signedNumberToHexStringLE, hexToDecimal, numberToHexString, decimalToOpCode } = require('../utils');
+
+// Compiles a single push of an arbitrary-length buffer, for constructing
+// test-only script fixtures without a Bitcoin script-encoding dependency.
+// Only handles direct pushes (buffers under 76 bytes), which is all these tests need.
+const pushBuffer = (buffer) => Buffer.concat([Buffer.from([buffer.length]), buffer]);
 
 // Deterministic powpeg public keys (generated with seeds segwitFed1..3)
 const POWPEG_PUBLIC_KEYS = [
@@ -187,13 +190,13 @@ describe('flyover redeem scripts', () => {
         });
 
         it('returns false for scripts that are not flyover-shaped', () => {
-            // unparseable script (decompile returns null) and a script with fewer than 3 chunks
+            // too short to even contain the 34-byte prefix
             expect(redeemScriptParser.isFlyoverRedeemScript(Buffer.from('4c', 'hex'))).to.be.false;
             expect(redeemScriptParser.isFlyoverRedeemScript(Buffer.from('51', 'hex'))).to.be.false;
-            // 3+ chunks but the first push is not 32 bytes
-            expect(redeemScriptParser.isFlyoverRedeemScript(Buffer.from(script.compile([Buffer.alloc(20), opcodes.OP_DROP, opcodes.OP_NOTIF])))).to.be.false;
-            // 32-byte first push but the second chunk is not OP_DROP
-            expect(redeemScriptParser.isFlyoverRedeemScript(Buffer.from(script.compile([Buffer.alloc(32), opcodes.OP_NOTIF, opcodes.OP_NOTIF])))).to.be.false;
+            // first push is not 32 bytes
+            expect(redeemScriptParser.isFlyoverRedeemScript(Buffer.concat([pushBuffer(Buffer.alloc(20)), Buffer.from([opcodes.OP_DROP, opcodes.OP_NOTIF])]))).to.be.false;
+            // 32-byte first push, long enough, but the second chunk is not OP_DROP
+            expect(redeemScriptParser.isFlyoverRedeemScript(Buffer.concat([pushBuffer(Buffer.alloc(32)), Buffer.from([opcodes.OP_NOTIF, opcodes.OP_NOTIF])]))).to.be.false;
         });
     });
 

--- a/test/redeem-script-parser.test.js
+++ b/test/redeem-script-parser.test.js
@@ -2,7 +2,7 @@ const redeemScriptParser = require('../index');
 const expect = require('chai').expect;
 const { ERROR_MESSAGES, MAX_CSV_VALUE } = require('../constants');
 const rawRedeemScripts = require('./resources/test-redeem-scripts.json');
-const { OPS: opcodes, signedNumberToHexStringLE, hexToDecimal, numberToHexString, decimalToOpCode } = require('../utils');
+const { OPS: opcodes, signedNumberToHexStringLE, hexToDecimal, numberToHexString } = require('../utils');
 
 // Compiles a single push of an arbitrary-length buffer, for constructing
 // test-only script fixtures without a Bitcoin script-encoding dependency.
@@ -48,15 +48,16 @@ const checkPubKeysIncludedInRedeemScript = (pubKeys, redeemScript) => {
 // mirroring encodeMultisigNumber: a single OP_N opcode for 1-16, or a minimally-encoded
 // data push for 17-20 (there's no OP_17..OP_20). Returns the position after the chunk.
 const assertMultisigNumber = (redeemScript, position, num) => {
-    if (decimalToOpCode[num] !== undefined) {
-        expect(redeemScript.subarray(position, position + 1).toString('hex')).to.be.eq(numberToHexString(decimalToOpCode[num]));
+    if (num <= 16) {
+        // OP_1..OP_16 are 0x51..0x60
+        expect(redeemScript.subarray(position, position + 1).toString('hex'))
+            .to.be.eq((0x50 + num).toString(16));
         return position + 1;
     }
-    const hex = signedNumberToHexStringLE(num);
-    const byteLength = hex.length / 2;
-    expect(redeemScript.subarray(position, position + 1).toString('hex')).to.be.eq(byteLength.toString(16).padStart(2, '0'));
-    expect(redeemScript.subarray(position + 1, position + 1 + byteLength).toString('hex')).to.be.eq(hex);
-    return position + 1 + byteLength;
+    // 17-20: no opcode, so a 1-byte data push
+    expect(redeemScript.subarray(position, position + 2).toString('hex'))
+        .to.be.eq('01' + num.toString(16));
+    return position + 2;
 };
 
 const validateRedeemScriptFormat = (redeemScript, pubKeys, erpPubKeys, csvValue) => {

--- a/test/redeem-script-parser.test.js
+++ b/test/redeem-script-parser.test.js
@@ -9,6 +9,14 @@ const { OPS: opcodes, signedNumberToHexStringLE, hexToDecimal, numberToHexString
 // Only handles direct pushes (buffers under 76 bytes), which is all these tests need.
 const pushBuffer = (buffer) => Buffer.concat([Buffer.from([buffer.length]), buffer]);
 
+// Deterministic compressed-pubkey-shaped (33-byte) hex strings, for exercising the
+// 1-16 public key count boundary. buildStandardMultiSigRedeemScript only checks
+// count and length here, not whether they're real EC points.
+const dummyPubKeys = (count) => Array.from(
+    { length: count },
+    (_, i) => Buffer.concat([Buffer.from([0x02]), Buffer.alloc(32, i + 1)]).toString('hex')
+);
+
 // Deterministic powpeg public keys (generated with seeds segwitFed1..3)
 const POWPEG_PUBLIC_KEYS = [
     '02543951140f6349680d84e51ef02d3a333b86c682018f7d02e70c0c6bf835d230',
@@ -110,6 +118,24 @@ describe('buildPowpegRedeemScript', () => {
         expect(() => redeemScriptParser.buildPowpegRedeemScript(POWPEG_PUBLIC_KEYS, ERP_PUBKEYS, ERP_CSV_VALUE - 0.5)).to.throw(ERROR_MESSAGES.INVALID_CSV_VALUE);
     });
 
+    it('fails for an invalid public key count', () => {
+        // fails because there are no powpeg public keys
+        expect(() => redeemScriptParser.buildPowpegRedeemScript([], ERP_PUBKEYS, ERP_CSV_VALUE)).to.throw(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
+        // fails because there are too many powpeg public keys
+        expect(() => redeemScriptParser.buildPowpegRedeemScript(dummyPubKeys(17), ERP_PUBKEYS, ERP_CSV_VALUE)).to.throw(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
+        // fails because there are no erp public keys
+        expect(() => redeemScriptParser.buildPowpegRedeemScript(POWPEG_PUBLIC_KEYS, [], ERP_CSV_VALUE)).to.throw(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
+        // fails because there are too many erp public keys
+        expect(() => redeemScriptParser.buildPowpegRedeemScript(POWPEG_PUBLIC_KEYS, dummyPubKeys(17), ERP_CSV_VALUE)).to.throw(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
+    });
+
+    it('should return a valid redeem script at the 16 public key boundary', () => {
+        const powpegKeys = dummyPubKeys(16);
+        const erpKeys = dummyPubKeys(16);
+        const redeemScript = redeemScriptParser.buildPowpegRedeemScript(powpegKeys, erpKeys, ERP_CSV_VALUE);
+        validateRedeemScriptFormat(redeemScript, powpegKeys, erpKeys, ERP_CSV_VALUE);
+    });
+
     it('should return a valid powpeg redeem script', () => {
         const redeemScript = redeemScriptParser.buildPowpegRedeemScript(POWPEG_PUBLIC_KEYS, ERP_PUBKEYS, ERP_CSV_VALUE);
         validateRedeemScriptFormat(redeemScript, POWPEG_PUBLIC_KEYS, ERP_PUBKEYS, ERP_CSV_VALUE);
@@ -193,8 +219,8 @@ describe('flyover redeem scripts', () => {
             // too short to even contain the 34-byte prefix
             expect(redeemScriptParser.isFlyoverRedeemScript(Buffer.from('4c', 'hex'))).to.be.false;
             expect(redeemScriptParser.isFlyoverRedeemScript(Buffer.from('51', 'hex'))).to.be.false;
-            // first push is not 32 bytes
-            expect(redeemScriptParser.isFlyoverRedeemScript(Buffer.concat([pushBuffer(Buffer.alloc(20)), Buffer.from([opcodes.OP_DROP, opcodes.OP_NOTIF])]))).to.be.false;
+            // long enough, but the first push is not 32 bytes (33, not 32)
+            expect(redeemScriptParser.isFlyoverRedeemScript(Buffer.concat([pushBuffer(Buffer.alloc(33)), Buffer.from([opcodes.OP_DROP, opcodes.OP_NOTIF])]))).to.be.false;
             // 32-byte first push, long enough, but the second chunk is not OP_DROP
             expect(redeemScriptParser.isFlyoverRedeemScript(Buffer.concat([pushBuffer(Buffer.alloc(32)), Buffer.from([opcodes.OP_NOTIF, opcodes.OP_NOTIF])]))).to.be.false;
         });

--- a/test/redeem-script-parser.test.js
+++ b/test/redeem-script-parser.test.js
@@ -10,7 +10,7 @@ const { OPS: opcodes, signedNumberToHexStringLE, hexToDecimal, numberToHexString
 const pushBuffer = (buffer) => Buffer.concat([Buffer.from([buffer.length]), buffer]);
 
 // Deterministic compressed-pubkey-shaped (33-byte) hex strings, for exercising the
-// 1-16 public key count boundary. buildStandardMultiSigRedeemScript only checks
+// 1-20 public key count boundary. buildStandardMultiSigRedeemScript only checks
 // count and length here, not whether they're real EC points.
 const dummyPubKeys = (count) => Array.from(
     { length: count },
@@ -44,17 +44,32 @@ const checkPubKeysIncludedInRedeemScript = (pubKeys, redeemScript) => {
     }
 };
 
-const validateRedeemScriptFormat = (redeemScript, pubKeys, erpPubKeys, csvValue) => {
-    const OP_M = decimalToOpCode[parseInt(pubKeys.length / 2) + 1];
-    const OP_N = decimalToOpCode[pubKeys.length];
+// Asserts that redeemScript encodes `num` (a multisig M or N value) starting at `position`,
+// mirroring encodeMultisigNumber: a single OP_N opcode for 1-16, or a minimally-encoded
+// data push for 17-20 (there's no OP_17..OP_20). Returns the position after the chunk.
+const assertMultisigNumber = (redeemScript, position, num) => {
+    if (decimalToOpCode[num] !== undefined) {
+        expect(redeemScript.subarray(position, position + 1).toString('hex')).to.be.eq(numberToHexString(decimalToOpCode[num]));
+        return position + 1;
+    }
+    const hex = signedNumberToHexStringLE(num);
+    const byteLength = hex.length / 2;
+    expect(redeemScript.subarray(position, position + 1).toString('hex')).to.be.eq(byteLength.toString(16).padStart(2, '0'));
+    expect(redeemScript.subarray(position + 1, position + 1 + byteLength).toString('hex')).to.be.eq(hex);
+    return position + 1 + byteLength;
+};
 
-    const ERP_OP_M = decimalToOpCode[parseInt(erpPubKeys.length / 2) + 1];
-    const ERP_OP_N = decimalToOpCode[erpPubKeys.length];
+const validateRedeemScriptFormat = (redeemScript, pubKeys, erpPubKeys, csvValue) => {
+    const M = parseInt(pubKeys.length / 2) + 1;
+    const N = pubKeys.length;
+
+    const ERP_M = parseInt(erpPubKeys.length / 2) + 1;
+    const ERP_N = erpPubKeys.length;
 
     let position = 1;
     //  First byte is OP_NOTIF
     expect(redeemScript.subarray(0, position).toString('hex')).to.be.eq(numberToHexString(opcodes.OP_NOTIF));
-    expect(redeemScript.subarray(position, ++position).toString('hex')).to.be.eq(numberToHexString(OP_M));
+    position = assertMultisigNumber(redeemScript, position, M);
 
     // Check Publickeys in redeem script
     for (let i = 0; i < pubKeys.length; i++) {
@@ -65,7 +80,7 @@ const validateRedeemScriptFormat = (redeemScript, pubKeys, erpPubKeys, csvValue)
         position = position + pubKeyLength;
     }
 
-    expect(redeemScript.subarray(position, ++position).toString('hex')).to.be.eq(numberToHexString(OP_N));
+    position = assertMultisigNumber(redeemScript, position, N);
     expect(redeemScript.subarray(position, ++position).toString('hex')).to.be.eq(numberToHexString(opcodes.OP_CHECKMULTISIG));
     expect(redeemScript.subarray(position, ++position).toString('hex')).to.be.eq(numberToHexString(opcodes.OP_ELSE));
     const csvValuePushBytes = signedNumberToHexStringLE(csvValue).length / 2;
@@ -75,7 +90,7 @@ const validateRedeemScriptFormat = (redeemScript, pubKeys, erpPubKeys, csvValue)
     position = csvValueOffset;
     expect(redeemScript.subarray(position, ++position).toString('hex')).to.be.eq(numberToHexString(opcodes.OP_CHECKSEQUENCEVERIFY));
     expect(redeemScript.subarray(position, ++position).toString('hex')).to.be.eq(numberToHexString(opcodes.OP_DROP));
-    expect(redeemScript.subarray(position, ++position).toString('hex')).to.be.eq(numberToHexString(ERP_OP_M));
+    position = assertMultisigNumber(redeemScript, position, ERP_M);
 
     // Check ERP Publickeys in redeem script
     for (let i = 0; i < erpPubKeys.length; i++) {
@@ -86,7 +101,7 @@ const validateRedeemScriptFormat = (redeemScript, pubKeys, erpPubKeys, csvValue)
         position = position + pubKeyLength;
     }
 
-    expect(redeemScript.subarray(position, ++position).toString('hex')).to.be.eq(numberToHexString(ERP_OP_N));
+    position = assertMultisigNumber(redeemScript, position, ERP_N);
     expect(redeemScript.subarray(position, ++position).toString('hex')).to.be.eq(numberToHexString(opcodes.OP_CHECKMULTISIG));
     //  Last byte is OP_ENDIF
     expect(redeemScript.subarray(position, ++position).toString('hex')).to.be.eq(numberToHexString(opcodes.OP_ENDIF));
@@ -121,17 +136,33 @@ describe('buildPowpegRedeemScript', () => {
     it('fails for an invalid public key count', () => {
         // fails because there are no powpeg public keys
         expect(() => redeemScriptParser.buildPowpegRedeemScript([], ERP_PUBKEYS, ERP_CSV_VALUE)).to.throw(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
-        // fails because there are too many powpeg public keys
-        expect(() => redeemScriptParser.buildPowpegRedeemScript(dummyPubKeys(17), ERP_PUBKEYS, ERP_CSV_VALUE)).to.throw(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
+        // fails because there are too many powpeg public keys (OP_CHECKMULTISIG caps at 20)
+        expect(() => redeemScriptParser.buildPowpegRedeemScript(dummyPubKeys(21), ERP_PUBKEYS, ERP_CSV_VALUE)).to.throw(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
         // fails because there are no erp public keys
         expect(() => redeemScriptParser.buildPowpegRedeemScript(POWPEG_PUBLIC_KEYS, [], ERP_CSV_VALUE)).to.throw(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
         // fails because there are too many erp public keys
-        expect(() => redeemScriptParser.buildPowpegRedeemScript(POWPEG_PUBLIC_KEYS, dummyPubKeys(17), ERP_CSV_VALUE)).to.throw(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
+        expect(() => redeemScriptParser.buildPowpegRedeemScript(POWPEG_PUBLIC_KEYS, dummyPubKeys(21), ERP_CSV_VALUE)).to.throw(ERROR_MESSAGES.INVALID_PUBLIC_KEYS_COUNT);
     });
 
     it('should return a valid redeem script at the 16 public key boundary', () => {
         const powpegKeys = dummyPubKeys(16);
         const erpKeys = dummyPubKeys(16);
+        const redeemScript = redeemScriptParser.buildPowpegRedeemScript(powpegKeys, erpKeys, ERP_CSV_VALUE);
+        validateRedeemScriptFormat(redeemScript, powpegKeys, erpKeys, ERP_CSV_VALUE);
+    });
+
+    it('should return a valid redeem script for 17 public keys (no single-opcode N encoding above 16)', () => {
+        // N=17 falls outside OP_1..OP_16 and need the minimally-encoded data push
+        const powpegKeys = dummyPubKeys(17);
+        const erpKeys = dummyPubKeys(4);
+        const redeemScript = redeemScriptParser.buildPowpegRedeemScript(powpegKeys, erpKeys, ERP_CSV_VALUE);
+        validateRedeemScriptFormat(redeemScript, powpegKeys, erpKeys, ERP_CSV_VALUE);
+    });
+
+    it('should return a valid redeem script for 20 public keys (max public key count)', () => {
+        // N=20 falls outside OP_1..OP_16 and need the minimally-encoded data push
+        const powpegKeys = dummyPubKeys(17);
+        const erpKeys = dummyPubKeys(4);
         const redeemScript = redeemScriptParser.buildPowpegRedeemScript(powpegKeys, erpKeys, ERP_CSV_VALUE);
         validateRedeemScriptFormat(redeemScript, powpegKeys, erpKeys, ERP_CSV_VALUE);
     });

--- a/utils.js
+++ b/utils.js
@@ -1,4 +1,29 @@
-const opcodes = require('bitcoinjs-lib').script.OPS;
+// Bitcoin script opcode values (BIP-62 / Script wiki), hardcoded so this library
+// doesn't need a Bitcoin script-encoding dependency for a handful of stable constants.
+const OPS = {
+    OP_1: 0x51,
+    OP_2: 0x52,
+    OP_3: 0x53,
+    OP_4: 0x54,
+    OP_5: 0x55,
+    OP_6: 0x56,
+    OP_7: 0x57,
+    OP_8: 0x58,
+    OP_9: 0x59,
+    OP_10: 0x5a,
+    OP_11: 0x5b,
+    OP_12: 0x5c,
+    OP_13: 0x5d,
+    OP_14: 0x5e,
+    OP_15: 0x5f,
+    OP_16: 0x60,
+    OP_NOTIF: 0x64,
+    OP_ELSE: 0x67,
+    OP_ENDIF: 0x68,
+    OP_DROP: 0x75,
+    OP_CHECKSEQUENCEVERIFY: 0xb2,
+    OP_CHECKMULTISIG: 0xae
+};
 
 const numberToHexString = (number) => number.toString(16);
 const hexToDecimal = hex => parseInt(hex, 16);
@@ -8,22 +33,22 @@ const ONE_BYTE_MASK = 0xFF;
 const ONE_BIT_MASK = 0x01;
 
 const decimalToOpCode = {
-    1: opcodes.OP_1,
-    2: opcodes.OP_2,
-    3: opcodes.OP_3,
-    4: opcodes.OP_4,
-    5: opcodes.OP_5,
-    6: opcodes.OP_6,
-    7: opcodes.OP_7,
-    8: opcodes.OP_8,
-    9: opcodes.OP_9,
-    10: opcodes.OP_10,
-    11: opcodes.OP_11,
-    12: opcodes.OP_12,
-    13: opcodes.OP_13,
-    14: opcodes.OP_14,
-    15: opcodes.OP_15,
-    16: opcodes.OP_16
+    1: OPS.OP_1,
+    2: OPS.OP_2,
+    3: OPS.OP_3,
+    4: OPS.OP_4,
+    5: OPS.OP_5,
+    6: OPS.OP_6,
+    7: OPS.OP_7,
+    8: OPS.OP_8,
+    9: OPS.OP_9,
+    10: OPS.OP_10,
+    11: OPS.OP_11,
+    12: OPS.OP_12,
+    13: OPS.OP_13,
+    14: OPS.OP_14,
+    15: OPS.OP_15,
+    16: OPS.OP_16
 }
 
 /**
@@ -60,6 +85,7 @@ const decimalToOpCode = {
 };
 
 module.exports = {
+    OPS,
     numberToHexString,
     hexToDecimal,
     decimalToOpCode,


### PR DESCRIPTION
This pull request removes the dependency on `bitcoinjs-lib` by replacing all uses of its script opcode constants with locally defined equivalents. It introduces a local `OPS` object for Bitcoin script opcodes, updates all code and tests to use these, and simplifies script handling logic. This reduces external dependencies and makes the codebase more self-contained.

**Dependency removal and opcode handling:**

* Removed the `bitcoinjs-lib` dependency and replaced all references to its script opcodes with a locally defined `OPS` object in `utils.js`. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L1-R2) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L19-L21) [[3]](diffhunk://#diff-fda8f0e13abe3d5c5685ad895fa528dd6067c41b66b6ebc6d1de71ca9a704d8dL1-R26)
* Updated `decimalToOpCode` to use the new `OPS` constants instead of those from `bitcoinjs-lib`.

**Code refactoring:**

* Refactored script construction functions in `index.js` (`buildStandardMultiSigRedeemScript`, `buildPowpegRedeemScript`, and others) to use the local `OPS` object and removed all usage of `bitcoinjs-lib` functions for script building. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L12-R23) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L54-R77) [[3]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L86-R94)
* Changed the flyover redeem script detection logic to use byte-level checks instead of `bitcoinjs-lib`’s script decompilation, making the check more direct and dependency-free. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L122-R136) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R118)

**Test updates:**

* Updated tests to use the local `OPS` object and added a helper (`pushBuffer`) for script construction, removing reliance on `bitcoinjs-lib` in tests.
* Adjusted flyover redeem script tests to match the new detection logic and construction methods.

**Exports and utility changes:**

* Exported the new `OPS` object from `utils.js` for use throughout the codebase.

These changes make the codebase more lightweight, portable, and easier to maintain by reducing reliance on external libraries for stable Bitcoin script constants.